### PR TITLE
Update the CircleCI config to use the Fugue CLI instead of API

### DIFF
--- a/.circleci/config-no-conftest.backup
+++ b/.circleci/config-no-conftest.backup
@@ -103,6 +103,9 @@ jobs:
       - run:
          name: scan-env
          command: |
+           wget -O fugue https://github.com/fugue/fugue-client/releases/download/v0.13.1/fugue-linux-amd64
+           chmod +x fugue
+           sudo mv fugue /usr/local/bin
            set -e
            bash ./scan.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,9 @@ jobs:
       - run:
          name: scan-env
          command: |
+           wget -O fugue https://github.com/fugue/fugue-client/releases/download/v0.13.1/fugue-linux-amd64
+           chmod +x fugue
+           sudo mv fugue /usr/local/bin
            set -e
            bash ./scan.sh
          


### PR DESCRIPTION
Part 1 of this example now uses the Fugue CLI instead of the API, so the CircleCI config (with and without Conftest) has been updated to match. See https://github.com/fugue/example-tf-circleci/pull/1 for details.